### PR TITLE
fix segfault

### DIFF
--- a/vlang_tools/publishingtools/publtools.v
+++ b/vlang_tools/publishingtools/publtools.v
@@ -26,6 +26,9 @@ pub fn new() PublTools{
 
 pub fn (mut publtools PublTools) site_get(name string) Site{	
 	name_lower := name_fix(name)
+	if name_lower !in publtools.sites {
+		publtools.sites[name_lower] = Site{}
+	}
 	return publtools.sites[name_lower]
 }
 
@@ -114,7 +117,7 @@ pub fn (mut publtools PublTools) process() {
 		for key in site.pages.keys(){
 			mut page := site.pages[key]
 			//not mutable
-			mut pageactor := PageActor{page:&page, site:&site, publtools:&publtools}
+			mut pageactor := PageActor{page: &page, site: &site, publtools: publtools}
 			pageactor.process()
 		}	
 		// for key in site.images.keys(){


### PR DESCRIPTION
This pr has the workaround for the incompletely initialized object retrieved from a map by a non existing key.
It just adds an empty struct of type `Site` into the map for the non existing key (which is however with properly initialized map fields), so that later `return publtools.sites[name_lower]` can find it and return it, instead of the partially uninitialized Site value (the map fields of which then cause segfaults, due to them being not properly initialized).