### PR TITLE
fix for vredis2.socket_read_line, needs V 81fd4964

### DIFF
--- a/vlang_tools/test2.v
+++ b/vlang_tools/test2.v
@@ -1,27 +1,9 @@
-
-import io
-
 import vredis2
-
-mut redis := vredis2.connect("localhost:6379") or {
-		panic(err)
-	}
-
-redis.set("test","some data")
-r := redis.get_string("test") or {
-	println("there is data in the readline, just can't read it")
-	println("will now do a blocking read which times out and then will show the data")
-	println("why does the readline not work???, and here it does?")
-	println("other question: what to do to make timeout smaller")
-
-	// redis.socket_read_line() or {panic("try once more")} //fails as well
-
-	//the next will find the data, why is that?
-	a := io.read_all(reader: redis.socket) or {panic(err)}
-	println(a.bytestr())
-
-	//panic the original error
-	panic(err)
-	}
-
-println(r)
+mut redis := vredis2.connect('localhost:6379') or { panic(err) }
+redis.set('test', 'some data')
+r := redis.get_string('test') or {
+	panic('>>>>> err: $err | errcode: $errcode')
+}
+eprintln('--------------------------------')
+eprintln(r)
+eprintln('--------------------------------')


### PR DESCRIPTION
With this PR:
![image](https://user-images.githubusercontent.com/26967/103296993-00466180-4a00-11eb-8138-e4512209bd22.png)

Notes: I restored the old blocking method .read_line() on the `net`'s TcpConn.

Unfortunately I could not debug the problem using the new IO buffered reader for now.

Note also that I added a `time.sleep_ms(1)` call inside Redis.encode_send . Without it, it seems that reading fails because I think it is done before all the send data is processed by the redis server. 
Another possible fix for that, is adding a retry loop inside socket_read_line, that tries to read a line several times with a time.sleep_ms(1) between the calls, and only returning error when say 5 retries failed in a row.

I did not implement the retry loop logic, because it is more complex, and I wanted to make as little changes as possible to keep the PR cleaner.