### PR TITLE
vredis2: rewrite client with some tests

### DIFF
--- a/vlang_tools/test2.v
+++ b/vlang_tools/test2.v
@@ -1,9 +1,111 @@
 import vredis2
-mut redis := vredis2.connect('localhost:6379') or { panic(err) }
-redis.set('test', 'some data')
-r := redis.get_string('test') or {
-	panic('>>>>> err: $err | errcode: $errcode')
+
+fn redistest() ? bool {
+	mut redis := vredis2.connect('localhost:6379')?
+	redis.set('test', 'some data')?
+	redis.set('hello', "bla\r\nbli\r\nblu")?
+
+	mut r := redis.get('test')?
+	eprintln(r)
+
+	r = redis.get('hello')?
+	eprintln(r)
+
+	redis.set('counter', "0")?
+
+	mut i := redis.incrby('counter', 17)?
+	r = redis.get('counter')?
+	println(i)
+
+	i = redis.incrby('counter', 10)?
+	println(i)
+
+	i = redis.incr('counter')?
+	println(i)
+
+	i = redis.decrby('counter', 5)?
+	println(i)
+
+	i = redis.decr('counter')?
+	println(i)
+
+	r = redis.get('counter')?
+	println(r)
+
+	mut f := redis.incrbyfloat('counter', 1.42)?
+	println(f)
+
+	i = redis.append("test", ", added")?
+	println(i)
+
+	r = redis.get('test')?
+	println(r)
+
+	i = redis.rpush("push", "rpush")?
+	println(i)
+
+	i = redis.lpush("push", "lpush")?
+	println(i)
+
+	r = redis.getset("test", "newvalue")?
+	println(r)
+
+	r = redis.get("test")?
+	println(r)
+
+	r = redis.getrange("test", 1, 4)?
+	println(r)
+
+	r = redis.getrange("nonexist", 0, 42)?
+	println(r)
+
+	r = redis.randomkey()?
+	println(r)
+
+	i = redis.strlen("test")?
+	println(i)
+
+	// should fails wrong type
+	i = redis.strlen("push") or { 0 }
+	println(i)
+
+	i = redis.llen("push")?
+	println(i)
+
+	r = redis.lpop("push")?
+	println(r)
+
+	r = redis.rpop("push")?
+	println(r)
+
+	i = redis.ttl("push")?
+	println(i)
+
+	// should be nil
+	r = redis.rpop("push") or { if err == "(nil)" { true } else { false } "" }
+
+	i = redis.pttl("push")?
+	println(i)
+
+	i = redis.del("push")?
+	println(i)
+
+	i = redis.llen("push")?
+	println(i)
+
+	// should fails
+	i = redis.llen("counter") or { 0 }
+
+	mut b := redis.rename("test", "newtest")?
+	println(b)
+
+
+	// array example support
+	mut cursor, values := redis.scan(0)?
+	println(cursor)
+	println(values)
+
+	return true
 }
-eprintln('--------------------------------')
-eprintln(r)
-eprintln('--------------------------------')
+
+redistest() or { panic('err: $err | errcode: $errcode') }

--- a/vlang_tools/vredis2/vredis.v
+++ b/vlang_tools/vredis2/vredis.v
@@ -5,16 +5,9 @@ pub fn (mut r Redis) set(key string, value string)? {
 	r.send_ok(['SET', key, value])?
 }
 
-pub fn (mut r Redis) get_int(key string) ?int {
-	mut key2 := key.trim("\"'")
-	res := r.send(['GET', key2])?
-	return res[0].int()
-}
-
-pub fn (mut r Redis) get_string(key string) ?string {
-	mut key2 := key.trim("\"'")
-	res := r.send(['GET', key2])?
-	return res[0]
+pub fn (mut r Redis) get(key string) ?string {
+	// mut key2 := key.trim("\"'")
+	return r.send_strnil(['GET', key])
 }
 
 // pub fn (mut r Redis) get(key string) string {
@@ -30,316 +23,135 @@ pub fn (mut r Redis) get_string(key string) ?string {
 // 	return ""
 // }
 
+pub fn (mut r Redis) incrby(key string, increment int) ?int {
+	return r.send_int(['INCRBY', key, increment.str()])
+}
 
+pub fn (mut r Redis) incr(key string) ?int {
+	return r.incrby(key, 1)
+}
 
-// pub fn (mut r Redis) incrby(key string, increment int) ?int {
-// 	message := 'INCRBY "$key" $increment\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	rerr := parse_err(res)
-// 	if rerr != '' {
-// 		return error(rerr)
-// 	}
-// 	count := parse_int(res)
-// 	return count
-// }
+pub fn (mut r Redis) decr(key string) ?int {
+	return r.incrby(key, -1)
+}
 
-// pub fn (mut r Redis) incr(key string) ?int {
-// 	res := r.incrby(key, 1) or {
-// 		return error(err)
-// 	}
-// 	return res
-// }
+pub fn (mut r Redis) decrby(key string, decrement int) ?int {
+	return r.incrby(key, -decrement)
+}
 
-// pub fn (mut r Redis) decr(key string) ?int {
-// 	res := r.incrby(key, -1) or {
-// 		return error(err)
-// 	}
-// 	return res
-// }
+pub fn (mut r Redis) incrbyfloat(key string, increment f64) ?f64 {
+	res := r.send_str(['INCRBYFLOAT', key, increment.str()])?
+	count := res.f64()
+	return count
+}
 
-// pub fn (mut r Redis) decrby(key string, decrement int) ?int {
-// 	res := r.incrby(key, -decrement) or {
-// 		return error(err)
-// 	}
-// 	return res
-// }
+pub fn (mut r Redis) append(key string, value string) ?int {
+	return r.send_int(['APPEND', key, value])
+}
 
-// pub fn (mut r Redis) incrbyfloat(key string, increment f64) ?f64 {
-// 	message := 'INCRBYFLOAT "$key" $increment\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	rerr := parse_err(r.socket_read_line() or {return error(err)})
-// 	if rerr != '' {
-// 		return error(rerr)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	count := parse_float(res)
-// 	return count
-// }
+pub fn (mut r Redis) setrange(key string, offset int, value string) ?int {
+	return r.send_int(['SETRANGE', key, offset.str(), value.str()])
+}
 
-// pub fn (mut r Redis) append(key string, value string) ?int {
-// 	message := 'APPEND "$key" "$value"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	count := parse_int(r.socket_read_line() or {return error(err)})
-// 	return count
-// }
+pub fn (mut r Redis) lpush(key string, element string) ?int {
+	return r.send_int(['LPUSH', key, element])
+}
 
-// pub fn (mut r Redis) setrange(key string, offset int, value string) ?int {
-// 	message := 'SETRANGE "$key" $offset "$value"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	count := parse_int(r.socket_read_line() or {return error(err)})
-// 	return count
-// }
+pub fn (mut r Redis) rpush(key string, element string) ?int {
+	return r.send_int(['RPUSH', key, element])
+}
 
-// pub fn (mut r Redis) lpush(key string, element string) ?int {
-// 	message := 'LPUSH "$key" "$element"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	count := parse_int(r.socket_read_line() or {return error(err)})
-// 	return count
-// }
+pub fn (mut r Redis) expire(key string, seconds int) ?int {
+	return r.send_int(['EXPIRE', key, seconds.str()])
+}
 
-// pub fn (mut r Redis) rpush(key string, element string) ?int {
-// 	message := 'RPUSH "$key" "$element"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	count := parse_int(r.socket_read_line() or {return error(err)})
-// 	return count
-// }
+pub fn (mut r Redis) pexpire(key string, millis int) ?int {
+	return r.send_int(['PEXPIRE', key, millis.str()])
+}
 
-// pub fn (mut r Redis) expire(key string, seconds int) ?int {
-// 	message := 'EXPIRE "$key" $seconds\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	count := parse_int(res)
-// 	return count
-// }
+pub fn (mut r Redis) expireat(key string, timestamp int) ?int {
+	return r.send_int(['EXPIREAT', key, timestamp.str()])
+}
 
-// pub fn (mut r Redis) pexpire(key string, millis int) ?int {
-// 	message := 'PEXPIRE "$key" $millis\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	count := parse_int(res)
-// 	return count
-// }
+pub fn (mut r Redis) pexpireat(key string, millistimestamp i64) ?int {
+	return r.send_int(['PEXPIREAT', key, millistimestamp.str()])
+}
 
-// pub fn (mut r Redis) expireat(key string, timestamp int) ?int {
-// 	message := 'EXPIREAT "$key" $timestamp\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	count := parse_int(res)
-// 	return count
-// }
+pub fn (mut r Redis) persist(key string) ?int {
+	return r.send_int(['PERSIST', key])
+}
 
-// pub fn (mut r Redis) pexpireat(key string, millistimestamp i64) ?int {
-// 	message := 'PEXPIREAT "$key" $millistimestamp\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	count := parse_int(res)
-// 	return count
-// }
+pub fn (mut r Redis) getset(key string, value string) ?string {
+	return r.send_strnil(['GETSET', key, value])
+}
 
-// pub fn (mut r Redis) persist(key string) ?int {
-// 	message := 'PERSIST "$key"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	count := parse_int(res)
-// 	return count
-// }
+pub fn (mut r Redis) getrange(key string, start int, end int) ?string {
+	return r.send_str(['GETRANGE', key, start.str(), end.str()])
+}
 
+pub fn (mut r Redis) randomkey() ?string {
+	return r.send_strnil(['RANDOMKEY'])
+}
 
-// pub fn (mut r Redis) getset(key string, value string) ?string {
-// 	message := 'GETSET "$key" $value\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	len := parse_int(res)
-// 	if len == -1 {
-// 		return ''
-// 	}
-// 	return r.socket_read_line() or {return error(err)}[0..len]
-// }
+pub fn (mut r Redis) strlen(key string) ?int {
+	return r.send_int(['STRLEN', key])
+}
 
-// pub fn (mut r Redis) getrange(key string, start int, end int) ?string {
-// 	message := 'GETRANGE "$key" $start $end\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	len := parse_int(res)
-// 	if len == 0 {
-// 		r.socket_read_line() or {return error(err)}
-// 		return ''
-// 	}
-// 	return r.socket_read_line() or {return error(err)}[0..len]
-// }
+pub fn (mut r Redis) lpop(key string) ?string {
+	return r.send_strnil(['LPOP', key])
+}
 
-// pub fn (mut r Redis) randomkey() ?string {
-// 	message := 'RANDOMKEY\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	len := parse_int(res)
-// 	if len == -1 {
-// 		return error('database is empty')
-// 	}
-// 	return r.socket_read_line() or {return error(err)}[0..len]
-// }
+pub fn (mut r Redis) rpop(key string) ?string {
+	return r.send_strnil(['RPOP', key])
+}
 
-// pub fn (mut r Redis) strlen(key string) ?int {
-// 	message := 'STRLEN "$key"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	count := parse_int(res)
-// 	return count
-// }
+pub fn (mut r Redis) llen(key string) ?int {
+	return r.send_int(['LLEN', key])
+}
 
-// pub fn (mut r Redis) lpop(key string) ?string {
-// 	message := 'LPOP "$key"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	len := parse_int(res)
-// 	if len == -1 {
-// 		return error('key not found')
-// 	}
-// 	return r.socket_read_line() or {return error(err)}[0..len]
-// }
+pub fn (mut r Redis) ttl(key string) ?int {
+	return r.send_int(['TTL', key])
+}
 
-// pub fn (mut r Redis) rpop(key string) ?string {
-// 	message := 'RPOP "$key"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	len := parse_int(res)
-// 	if len == -1 {
-// 		return error('key not found')
-// 	}
-// 	return r.socket_read_line() or {return error(err)}[0..len]
-// }
+pub fn (mut r Redis) pttl(key string) ?int {
+	return r.send_int(['PTTL', key])
+}
 
-// pub fn (mut r Redis) llen(key string) ?int {
-// 	message := 'LLEN "$key"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	rerr := parse_err(res)
-// 	if rerr != '' {
-// 		return error(rerr)
-// 	}
-// 	count := parse_int(res)
-// 	return count
-// }
+pub fn (mut r Redis) exists(key string) ?int {
+	return r.send_int(['EXISTS', key])
+}
 
-// pub fn (mut r Redis) ttl(key string) ?int {
-// 	message := 'TTL "$key"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	count := parse_int(res)
-// 	return count
-// }
+pub fn (mut r Redis) del(key string) ?int {
+	return r.send_int(['DEL', key])
+}
 
-// pub fn (mut r Redis) pttl(key string) ?int {
-// 	message := 'PTTL "$key"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	count := parse_int(res)
-// 	return count
-// }
+pub fn (mut r Redis) rename(key string, newkey string) ?bool {
+	return r.send_ok(['RENAME', key, newkey])
+}
 
-// pub fn (mut r Redis) exists(key string) ?int {
-// 	message := 'EXISTS "$key"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	count := parse_int(res)
-// 	return count
-// }
+pub fn (mut r Redis) renamenx(key string, newkey string) ?int {
+	return r.send_int(['RENAMENX', key, newkey])
+}
 
-// pub fn (mut r Redis) del(key string) ?int {
-// 	message := 'DEL "$key"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	count := parse_int(res)
-// 	return count
-// }
+pub fn (mut r Redis) flushall() ?bool {
+	return r.send_ok(['FLUSHALL'])
+}
 
-// pub fn (mut r Redis) rename(key string, newkey string) bool {
-// 	message := 'RENAME "$key" "$newkey"\r\n'
-// 	r.write(message) or {
-// 		return false
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}[0..3]
-// 	match res {
-// 		'+OK' {
-// 			return true
-// 		}
-// 		else {
-// 			return false
-// 		}
-// 	}
-// }
+pub fn (mut r Redis) scan(cursor int) ? (string, []string) {
+	res := r.send_list(['SCAN', cursor.str()])?
+	if res[0].datatype != RedisValTypes.str {
+		return error("Redis SCAN wrong response type (cursor)")
+	}
 
-// pub fn (mut r Redis) renamenx(key string, newkey string) ?int {
-// 	message := 'RENAMENX "$key" "$newkey"\r\n'
-// 	r.write(message) or {
-// 		return error(err)
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}
-// 	rerr := parse_err(res)
-// 	if rerr != '' {
-// 		return error(rerr)
-// 	}
-// 	count := parse_int(res)
-// 	return count
-// }
+	if res[1].datatype != RedisValTypes.list {
+		return error("Redis SCAN wrong response type (list content)")
+	}
 
-// pub fn (mut r Redis) flushall() bool {
-// 	message := 'FLUSHALL\r\n'
-// 	r.write(message) or {
-// 		return false
-// 	}
-// 	res := r.socket_read_line() or {return error(err)}[0..3]
-// 	match res {
-// 		'+OK' {
-// 			return true
-// 		}
-// 		else {
-// 			return false
-// 		}
-// 	}
-// }
+	mut values := []string{}
+
+	for i in 0 .. res[1].list.len {
+		values << res[1].list[i].str
+	}
+
+	return res[0].str, values
+}


### PR DESCRIPTION
Update `vredis2` client handler, each redis commands commented are re-implemented, with `SCAN` command addition.

`test2.v` contains call to mostly all commands defined in `vredis.v`

There are couple redis send command handler wrapper:
  - `send`: raw send request which returns a raw RedisValue response
  - `send_ok`: expect +OK as response and returns true/false
  - `send_int`: expect an integer as response and returns it
  - `send_str`: expect a string as response, nil are not handled
  - `send_strnil`: expect a string as response or a nil, if a nil is received, an error is triggered: `(nil)`
  - `send_list`: expect an array as response, array can be iterated based on RedisValue.list content and fields

Array are fully supported, neasted array should be supported as well.

Notes:
`GET` from redis always returns string or nil, if expected response is number, this should be handled by caller, not vredis itself