### PR TITLE
Add .gitpod.Dockerfile

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,18 @@
+FROM thevlang/vlang:latest
+
+RUN apt-get update && \
+    apt-get install -yq sudo
+
+RUN apt install -y redis-server
+
+### Gitpod user ###
+# '-l': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod \
+    # passwordless sudo for users in the 'sudo' group
+    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+ENV HOME=/home/gitpod
+WORKDIR $HOME
+
+USER gitpod
+
+ENTRYPOINT [ "entrypoint.sh" ]

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,5 @@
+image:
+  file: .gitpod.Dockerfile
 # # Commands to start on workspace startup
 tasks:
   - init: bash prepare.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+systemctl start redis-server
+
+exec sh

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,10 +1,11 @@
 set -ex
 echo 1 > log.txt
 sudo apt install redis-server -y
+sudo /etc/init.d/redis-server start
+
 bash install.sh
 bash build.sh
 echo 2 >> log.txt
-sudo /etc/init.d/redis-server start
 echo 3 >> log.txt
 set +ex
 # publishtools flatten


### PR DESCRIPTION
moves redis installation to `.gitpod.Dockerfile`
![image](https://user-images.githubusercontent.com/64129/122796999-4994b100-d2bf-11eb-99e4-0854dc3afe3a.png)

after that when starting the workspace redis is running and the image is based on thevalng/vlang to have vlang binaries bundled in /opt/vlang